### PR TITLE
update Podfile in order to conform to CocoaPods 1.0 syntax

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,10 @@
 platform :ios, "8.0"
-pod "NYXImagesKit"
-pod "ICTextView", ">= 2.0.1"
-pod "FCFileManager"
-pod "QBImagePickerController", ">= 3.0.0"
-pod "JSQMessagesViewController"
+
+target 'RubyPico' do
+  # Pods for RubyPico
+  pod "NYXImagesKit"
+  pod "ICTextView", ">= 2.0.1"
+  pod "FCFileManager"
+  pod "QBImagePickerController", ">= 3.0.0"
+  pod "JSQMessagesViewController"
+end


### PR DESCRIPTION
CocoaPods 1.0 で Podfile の書き方が変わり `pod install` でエラーになるので
CocoaPods 1.0 の記述にあわせてみました。
